### PR TITLE
Fix parsing of importances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rater",
-  "version": "2.6.4",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rater",
-      "version": "2.6.4",
+      "version": "2.7.1",
       "license": "(MIT OR CC-BY-4.0)",
       "devDependencies": {
         "@babel/core": "^7.9.0",
@@ -2337,9 +2337,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rater",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Wikipedia userscript that helps assess pages for WikiProjects",
   "homepage": "https://github.com/evad37/rater",
   "browser": "index.js",

--- a/rater-src/Template.js
+++ b/rater-src/Template.js
@@ -523,7 +523,7 @@ Template.prototype.setClassesAndImportances = function() {
 	
 	return API.get({
 		action: "parse",
-		title: "Talk:Sandbox",
+		title: "Talk:Wikipedia",
 		text: wikitextToParse,
 		prop: "categorieshtml"
 	})


### PR DESCRIPTION
The title param for action=parse must be the talk page of an actual article, not a disambiguation page or redirect, to work with the new version of Module:WikiProject banner