### PR TITLE
Scope OOUI dialog overrides to Rater's own window manager

### DIFF
--- a/rater-src/css.js
+++ b/rater-src/css.js
@@ -30,27 +30,22 @@ table.diff td div {
     overflow: auto;
 }` +
 
-// Override OOUI window manager preventing background scrolling/interaction
+// Override OOUI window manager preventing background scrolling/interaction.
+// Scoped to Rater's own window manager (.rater-windowManager), so that other
+// OOUI dialogs (e.g. OO.ui.confirm in #mw-teleport-target) keep their default
+// fixed positioning and remain visible.
 `html body.rater-mainWindow-open {
 	position: unset;
 	overflow: unset;
 }
-html body.rater-mainWindow-open .oo-ui-windowManager-modal > .oo-ui-dialog.oo-ui-window-active {
+html body.rater-mainWindow-open .rater-windowManager > .oo-ui-dialog.oo-ui-window-active {
     position: static;
     padding: 0;
 }` +
 // Increase z-index, to be above skin menus etc; smooth transition for dragging (transform:translate)
-`html body.rater-mainWindow-open .oo-ui-dialog.oo-ui-window-active > div {
+`html body.rater-mainWindow-open .rater-windowManager > .oo-ui-dialog.oo-ui-window-active > div {
     z-index: 110;
     transition: all 0.25s ease-out 0s, transform 0s !important
-}
-` + 
-// Ensure close dialog is visible
-`html body.rater-mainWindow-open #mw-teleport-target {
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right:0;
 }
 `;
 

--- a/rater-src/windowManager.js
+++ b/rater-src/windowManager.js
@@ -11,6 +11,9 @@ factory.register(MainWindow);
 var manager = new OO.ui.WindowManager( {
 	"factory": factory
 } );
+// Marker class, so CSS rules can target Rater's own windows without affecting
+// other OOUI dialogs (e.g. OO.ui.confirm, which renders in #mw-teleport-target)
+manager.$element.addClass( "rater-windowManager" );
 $( document.body ).append( manager.$element );
 
 export default manager;


### PR DESCRIPTION
Add a .rater-windowManager marker class to Rater's window manager and scope the position:static/z-index overrides to it, instead of matching every modal OOUI dialog. Other dialogs such as OO.ui.confirm (which renders in #mw-teleport-target) now keep their default fixed positioning and stay visible, so the #mw-teleport-target full-viewport workaround can be removed.

Fix #38.