### PR TITLE
raise Rater window z-index above Timeless sidebar menus

### DIFF
--- a/rater-src/css.js
+++ b/rater-src/css.js
@@ -43,8 +43,10 @@ html body.rater-mainWindow-open .rater-windowManager > .oo-ui-dialog.oo-ui-windo
     padding: 0;
 }` +
 // Increase z-index, to be above skin menus etc; smooth transition for dragging (transform:translate)
+// 400 keeps Rater above Timeless sidebar dropdowns (.sidebar-inner, 350) / menus-cover (300) /
+// fixed header (200), but below #mw-teleport-target (450) so OO.ui.confirm dialogs stay on top.
 `html body.rater-mainWindow-open .rater-windowManager > .oo-ui-dialog.oo-ui-window-active > div {
-    z-index: 110;
+    z-index: 400;
     transition: all 0.25s ease-out 0s, transform 0s !important
 }
 `;


### PR DESCRIPTION
Timeless sidebar dropdowns (.sidebar-inner, z-index 350), the mobile menus-cover (300) and fixed header (200) can obscure the main window on narrow viewports. Raise the window frame to 400, which stays below #mw-teleport-target (450) so OO.ui.confirm dialogs remain on top.

Fix #40.

Co-authored-by: deepseek-v4-flash